### PR TITLE
Add cache_bug class method for generating cached instance of EnhancedBug

### DIFF
--- a/bugmon/bug.py
+++ b/bugmon/bug.py
@@ -319,11 +319,9 @@ class EnhancedBug(Bug):
         """
         if self._bugsy is None:
             attachments = self._bug.get("attachments", [])
-            self._bug["attachments"] = [LocalAttachment(**a) for a in attachments]
-        else:
-            self._bug["attachments"] = super().get_attachments()
+            return [LocalAttachment(**a) for a in attachments]
 
-        return self._bug["attachments"]
+        return super().get_attachments()
 
     def add_attachment(self, attachment):
         """
@@ -342,11 +340,9 @@ class EnhancedBug(Bug):
         """
         if self._bugsy is None:
             comments = self._bug.get("comments", [])
-            self._bug["comments"] = [LocalComment(**c) for c in comments]
-        else:
-            self._bug["comments"] = super().get_comments()
+            return [LocalComment(**c) for c in comments]
 
-        return self._bug["comments"]
+        return super().get_comments()
 
     def add_comment(self, comment):
         """

--- a/bugmon/bug.py
+++ b/bugmon/bug.py
@@ -3,6 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public License,
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
+# pylint: disable=too-many-public-methods
 import json
 import platform
 import re

--- a/bugmon/bug.py
+++ b/bugmon/bug.py
@@ -378,7 +378,7 @@ class EnhancedBug(Bug):
         else:
             pattern = re.compile(rf"(?:{HG_BASE}/releases/{alias}/rev/){REV_MATCH}")
 
-        comments = self.bug.get_comments()
+        comments = self.get_comments()
         for comment in sorted(comments, key=lambda c: c.creation_time, reverse=True):
             match = pattern.match(comment.text)
             if match:

--- a/bugmon/bug.py
+++ b/bugmon/bug.py
@@ -414,6 +414,30 @@ class EnhancedBug(Bug):
 
         super().update()
 
+    @classmethod
+    def cache_bug(cls, bug):
+        """
+        Create a cached instance of EnhancedBug
+
+        :param bug: A EnhancedBug instance with Bugsy
+        :type bug: EnhancedBug
+        :return: A cached EnhancedBug instance
+        :rtype: EnhancedBug
+        """
+        # pylint: disable=protected-access
+        if bug._bugsy is None:
+            raise TypeError("Method not supported when using a cached bug")
+
+        bug_data = bug.to_dict()
+        attachments = bug.get_attachments()
+        bug_data["attachments"] = [a.to_dict() for a in attachments]
+
+        comments = bug.get_comments()
+        # pylint: disable=protected-access
+        bug_data["comments"] = [c._comment for c in comments]
+
+        return cls(None, **bug_data)
+
 
 class LocalAttachment(Attachment):
     """

--- a/bugmon/bug.py
+++ b/bugmon/bug.py
@@ -407,6 +407,13 @@ class EnhancedBug(Bug):
         """
         return json.dumps(self._bug, default=sanitize_bug)
 
+    def update(self):
+        """Update bug when a bugsy instance is present"""
+        if self._bugsy is None:
+            raise TypeError("Method not supported when using a cached bug")
+
+        super().update()
+
 
 class LocalAttachment(Attachment):
     """

--- a/tests/test_bug.py
+++ b/tests/test_bug.py
@@ -281,3 +281,18 @@ def test_bug_command_setter_remove_command(bug_fixture_prefetch):
     bug.commands = {}
 
     assert bug.whiteboard == "[something-else]"
+
+
+def test_bug_cache_bug(mocker, bug_fixture, comment_fixture, attachment_fixture):
+    """ Test EnhancedBug.cache_bug() """
+    data = copy.deepcopy(bug_fixture)
+    bug = EnhancedBug(bugsy=True, **data)
+
+    attachments = [LocalAttachment(**attachment_fixture)]
+    mocker.patch("bugmon.bug.EnhancedBug.get_attachments", return_value=attachments)
+    comments = [LocalComment(**comment_fixture)]
+    mocker.patch("bugmon.bug.EnhancedBug.get_comments", return_value=comments)
+
+    cached_bug = EnhancedBug.cache_bug(bug)
+    assert cached_bug.get_attachments() == attachments
+    assert cached_bug.get_comments() == comments


### PR DESCRIPTION
Previously, calling `get_comments` and `get_attachments` on a Bug with a Bugsy instance would be sufficient to cache the contents of the bug.  The problem is that repeated attempts to call either of those methods will raise due to https://github.com/MozillaSecurity/bugmon/issues/4.  This PR modifies those methods so that the data isn't saved in the bug data.

It further adds a `EnhancedBug.cache_bug` classmethod for properly downloading the necessary data for using a cached instance.